### PR TITLE
underline, strike-through, and code

### DIFF
--- a/lib/sanity/components/portable_text.ex
+++ b/lib/sanity/components/portable_text.ex
@@ -294,21 +294,27 @@ defmodule Sanity.Components.PortableText do
 
   @doc false
   @impl true
-  def mark(%{mark_type: "em"} = assigns) do
+  def mark(%{mark_type: mark_type} = assigns) when mark_type in ["code", "em", "strong"] do
     ~H"""
-    <em><%= render_slot(@inner_block) %></em>
-    """
-  end
-
-  def mark(%{mark_type: "strong"} = assigns) do
-    ~H"""
-    <strong><%= render_slot(@inner_block) %></strong>
+    <.dynamic_tag name={@mark_type}><%= render_slot(@inner_block) %></.dynamic_tag>
     """
   end
 
   def mark(%{mark_type: "link"} = assigns) do
     ~H"""
     <a href={@value.href}><%= render_slot(@inner_block) %></a>
+    """
+  end
+
+  def mark(%{mark_type: "strike-through"} = assigns) do
+    ~H"""
+    <del><%= render_slot(@inner_block) %></del>
+    """
+  end
+
+  def mark(%{mark_type: "underline"} = assigns) do
+    ~H"""
+    <u><%= render_slot(@inner_block) %></u>
     """
   end
 

--- a/test/sanity/components/portable_text_test.exs
+++ b/test/sanity/components/portable_text_test.exs
@@ -21,6 +21,34 @@ defmodule Sanity.Components.PortableTextTest do
     }
   ]
 
+  # Along with bold and italic, these are the marks which the Sanity editor supports by default
+  @default_marks [
+    %{
+      _key: "cac150e65d8a",
+      _type: "block",
+      children: [
+        %{_key: "12b6b9acccc7", _type: "span", marks: [], text: "normal "},
+        %{
+          _key: "76e4da946506",
+          _type: "span",
+          marks: ["underline"],
+          text: "underline"
+        },
+        %{_key: "4fe55bc49e50", _type: "span", marks: [], text: " "},
+        %{
+          _key: "4e5b993c130a",
+          _type: "span",
+          marks: ["strike-through"],
+          text: "strike"
+        },
+        %{_key: "75c152797366", _type: "span", marks: [], text: " "},
+        %{_key: "1c23c2bdba45", _type: "span", marks: ["code"], text: "code"}
+      ],
+      mark_defs: [],
+      style: "normal"
+    }
+  ]
+
   @blocks [
     %{
       _key: "4a62e0041050",
@@ -298,6 +326,14 @@ defmodule Sanity.Components.PortableTextTest do
     assert render_trimmed(&PortableText.portable_text/1, value: @bold_and_italic) == """
            <p>
              A <strong>bold</strong> <strong><em>word</em></strong>
+           </p>
+           """
+  end
+
+  test "default marks" do
+    assert render_trimmed(&PortableText.portable_text/1, value: @default_marks) == """
+           <p>
+             normal <u>underline</u> <del>strike</del> <code>code</code>
            </p>
            """
   end


### PR DESCRIPTION
The Sanity portable text editor has built-in support for these marks so we should support them by default.

https://www.sanity.io/docs/configuration#c88e9a7fb8ab